### PR TITLE
Add CI workflow and test publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,13 @@
 name: Publish Gem
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 jobs:
   publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The Publish workflow should only run on master and if there is a new version change.